### PR TITLE
Fix Local Build

### DIFF
--- a/io.github.brunofin.Cohesion.yml
+++ b/io.github.brunofin.Cohesion.yml
@@ -9,7 +9,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20
 
 build-options:
-  append-path: /usr/lib/sdk/node18/bin
+  append-path: /usr/lib/sdk/node20/bin
 
 finish-args:
   - --share=ipc


### PR DESCRIPTION
This fixes the path for node in the manifest to fix, building Cohesion. I'm honestly unsure why that didn't cause issues with the buildbot, but the manifest should match the version of the declared extension. I'll also include this PR in a few minor PRs I'll open soon to avoid a myriad of rebuilds.