### PR TITLE
Bump Flatpak Runtimes

### DIFF
--- a/io.github.brunofin.Cohesion.yml
+++ b/io.github.brunofin.Cohesion.yml
@@ -9,7 +9,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20
 
 build-options:
-  append-path: /usr/lib/sdk/node18/bin
+  append-path: /usr/lib/sdk/node20/bin
 
 finish-args:
   - --share=ipc

--- a/io.github.brunofin.Cohesion.yml
+++ b/io.github.brunofin.Cohesion.yml
@@ -1,10 +1,10 @@
 app-id: io.github.brunofin.Cohesion
 runtime: org.freedesktop.Platform
-runtime-version: "23.08"
+runtime-version: "24.08"
 sdk: org.freedesktop.Sdk
 
 base: org.electronjs.Electron2.BaseApp
-base-version: "23.08"
+base-version: "24.08"
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20
 


### PR DESCRIPTION
Updates the Flatpak runtimes to their most recent releases, found no regressions in my testing. Merge this second after #9 to keep wait-time on repeated rebuilds to a minimum.