### PR TITLE
Fix Cursor Theme and Scaling

### DIFF
--- a/io.github.brunofin.Cohesion.yml
+++ b/io.github.brunofin.Cohesion.yml
@@ -9,7 +9,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20
 
 build-options:
-  append-path: /usr/lib/sdk/node18/bin
+  append-path: /usr/lib/sdk/node20/bin
 
 finish-args:
   - --share=ipc

--- a/io.github.brunofin.Cohesion.yml
+++ b/io.github.brunofin.Cohesion.yml
@@ -21,6 +21,7 @@ finish-args:
   - --talk-name=com.canonical.indicator.application
   - --talk-name=org.ayatana.indicator.application
   - --filesystem=xdg-documents
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   
 command: cohesion
 

--- a/io.github.brunofin.Cohesion.yml
+++ b/io.github.brunofin.Cohesion.yml
@@ -1,10 +1,10 @@
 app-id: io.github.brunofin.Cohesion
 runtime: org.freedesktop.Platform
-runtime-version: "23.08"
+runtime-version: "24.08"
 sdk: org.freedesktop.Sdk
 
 base: org.electronjs.Electron2.BaseApp
-base-version: "23.08"
+base-version: "24.08"
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20
 


### PR DESCRIPTION
This fixes the look of custom cursor themes, as the app will fall back to the default cursor if this environment variable isn't set. This will also fix their scaling on certain setups to avoid the mouse cursor being miniscule. Merge this after #10.