### PR TITLE
Enable Wayland by Default

### DIFF
--- a/io.github.brunofin.Cohesion.yml
+++ b/io.github.brunofin.Cohesion.yml
@@ -9,7 +9,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20
 
 build-options:
-  append-path: /usr/lib/sdk/node18/bin
+  append-path: /usr/lib/sdk/node20/bin
 
 finish-args:
   - --share=ipc

--- a/io.github.brunofin.Cohesion.yml
+++ b/io.github.brunofin.Cohesion.yml
@@ -13,7 +13,8 @@ build-options:
 
 finish-args:
   - --share=ipc
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --device=dri
   - --share=network
@@ -22,6 +23,7 @@ finish-args:
   - --talk-name=org.ayatana.indicator.application
   - --filesystem=xdg-documents
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
   
 command: cohesion
 

--- a/io.github.brunofin.Cohesion.yml
+++ b/io.github.brunofin.Cohesion.yml
@@ -21,6 +21,7 @@ finish-args:
   - --talk-name=com.canonical.indicator.application
   - --talk-name=org.ayatana.indicator.application
   - --filesystem=xdg-documents
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   
 command: cohesion
 

--- a/io.github.brunofin.Cohesion.yml
+++ b/io.github.brunofin.Cohesion.yml
@@ -1,10 +1,10 @@
 app-id: io.github.brunofin.Cohesion
 runtime: org.freedesktop.Platform
-runtime-version: "23.08"
+runtime-version: "24.08"
 sdk: org.freedesktop.Sdk
 
 base: org.electronjs.Electron2.BaseApp
-base-version: "23.08"
+base-version: "24.08"
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20
 


### PR DESCRIPTION
This PR is the main reason I depended the other PRs on each other. The experience for the test build should be best like this :) Merge this last if you would like to enable Wayland by default. It should avoid the issue where people couldn't start Cohesion with Wayland enabled.

Resolves: https://github.com/brunofin/cohesion/issues/22