### PR TITLE
fix: add input method support

### DIFF
--- a/io.github.brunofin.Cohesion.yml
+++ b/io.github.brunofin.Cohesion.yml
@@ -76,4 +76,4 @@ modules:
         dest-filename: run.sh
         commands:
           - export TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}" # the tray icon needs this in order to work
-          - zypak-wrapper.sh /app/cohesion/cohesion "$@"
+          - zypak-wrapper.sh /app/cohesion/cohesion --enable-wayland-ime "$@"


### PR DESCRIPTION
After adding this parameter `--enable-wayland-ime`, I can use fcitx5 input method.

* fix issue brunofin/cohesion#41